### PR TITLE
Handle overlapping ranges

### DIFF
--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -127,7 +127,11 @@ impl<A> DFA<A> {
             for range in range_transitions.iter() {
                 let values = &range.values;
                 assert_eq!(values.len(), 1);
-                new_range_transitions.insert(range.start, range.end, values[0]);
+                new_range_transitions.insert(
+                    range.start,
+                    range.end,
+                    StateIdx(values[0].0 + n_current_states),
+                );
             }
 
             if let Some(next) = fail_transition {

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -84,13 +84,13 @@ impl<A> DFA<A> {
     pub fn add_range_transition(
         &mut self,
         state: StateIdx,
-        range_begin: char,
-        range_end: char,
+        range_begin: u32,
+        range_end: u32,
         next: StateIdx,
     ) {
         self.states[state.0]
             .range_transitions
-            .insert(range_begin as u32, range_end as u32, next);
+            .insert(range_begin, range_end, next);
     }
 
     pub fn add_fail_transition(&mut self, state: StateIdx, next: StateIdx) {

--- a/src/dfa/codegen.rs
+++ b/src/dfa/codegen.rs
@@ -1,7 +1,7 @@
 use super::{State, StateIdx, DFA};
 
 use crate::ast::{RuleKind, RuleRhs};
-use crate::range_map::{Range, RangeMap};
+use crate::range_map::RangeMap;
 
 use std::convert::TryFrom;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod dfa;
 mod display;
 mod nfa;
 mod nfa_to_dfa;
+mod range_set;
 mod regex_to_nfa;
 
 use ast::{Lexer, Regex, RegexOrFail, Rule, RuleRhs, SingleRule, Var};
@@ -508,5 +509,29 @@ mod tests {
         );
 
         test_simulate(&nfa, vec![("ab", Some(1)), ("ac", Some(2))]);
+    }
+
+    #[test]
+    fn overlapping_ranges() {
+        let mut nfa: NFA<usize> = NFA::new();
+
+        nfa.add_regex(
+            &Default::default(),
+            &Regex::Concat(
+                Box::new(Regex::CharSet(CharSet(vec![CharOrRange::Range('a', 'b')]))),
+                Box::new(Regex::Char('1')),
+            ),
+            1,
+        );
+        nfa.add_regex(
+            &Default::default(),
+            &Regex::Concat(
+                Box::new(Regex::CharSet(CharSet(vec![CharOrRange::Range('a', 'c')]))),
+                Box::new(Regex::Char('2')),
+            ),
+            2,
+        );
+
+        test_simulate(&nfa, vec![("a1", Some(1)), ("a2", Some(2))]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod dfa;
 mod display;
 mod nfa;
 mod nfa_to_dfa;
-mod range_set;
+mod range_map;
 mod regex_to_nfa;
 
 use ast::{Lexer, Regex, RegexOrFail, Rule, RuleRhs, SingleRule, Var};

--- a/src/nfa_to_dfa.rs
+++ b/src/nfa_to_dfa.rs
@@ -1,11 +1,13 @@
 use crate::dfa::DFA;
 use crate::nfa::NFA;
+use crate::range_map::RangeMap;
 
 use crate::dfa::StateIdx as DfaStateIdx;
 use crate::nfa::StateIdx as NfaStateIdx;
 
 use std::collections::hash_map::Entry;
 use std::collections::BTreeSet;
+use std::convert::TryFrom;
 
 use fxhash::{FxHashMap, FxHashSet};
 
@@ -53,8 +55,7 @@ pub fn nfa_to_dfa<A: Clone>(nfa: &NFA<A>) -> DFA<A> {
         finished_dfa_states.insert(current_dfa_state);
 
         let mut char_transitions: FxHashMap<char, FxHashSet<NfaStateIdx>> = Default::default();
-        let mut range_transitions: FxHashMap<(char, char), FxHashSet<NfaStateIdx>> =
-            Default::default();
+        let mut range_transitions: RangeMap<NfaStateIdx> = Default::default();
 
         for nfa_state in current_nfa_states.iter().copied() {
             if let Some(value) = nfa.get_accepting_state(nfa_state) {
@@ -71,10 +72,12 @@ pub fn nfa_to_dfa<A: Clone>(nfa: &NFA<A>) -> DFA<A> {
 
             // Collect range transitions
             for ((range_begin, range_end), next_states) in nfa.range_transitions(nfa_state) {
-                range_transitions
-                    .entry((*range_begin, *range_end))
-                    .or_default()
-                    .extend(next_states.iter().copied());
+                let next_states = next_states.iter().copied().collect::<Vec<NfaStateIdx>>();
+                range_transitions.insert_values(
+                    *range_begin as u32,
+                    *range_end as u32,
+                    &next_states,
+                );
             }
         }
 
@@ -82,9 +85,9 @@ pub fn nfa_to_dfa<A: Clone>(nfa: &NFA<A>) -> DFA<A> {
         for (char, mut char_states) in char_transitions.into_iter() {
             // For ranges that also cover the char we need to add the range transitions to the char
             // transition
-            for (range, range_states) in range_transitions.iter() {
-                if char >= range.0 && char <= range.1 {
-                    for range_state in range_states {
+            for range in range_transitions.iter() {
+                if char as u32 >= range.start && char as u32 <= range.end {
+                    for range_state in &range.values {
                         char_states.insert(*range_state);
                     }
                 }
@@ -100,11 +103,17 @@ pub fn nfa_to_dfa<A: Clone>(nfa: &NFA<A>) -> DFA<A> {
             work_list.push(closure);
         }
 
-        for ((range_begin, range_end), states) in range_transitions.into_iter() {
+        for range in range_transitions.into_iter() {
+            let state_set: FxHashSet<NfaStateIdx> = range.values.into_iter().collect();
             let closure: BTreeSet<NfaStateIdx> =
-                nfa.compute_state_closure(&states).into_iter().collect();
+                nfa.compute_state_closure(&state_set).into_iter().collect();
             let dfa_state = dfa_state_of_nfa_states(&mut dfa, &mut state_map, closure.clone());
-            dfa.add_range_transition(current_dfa_state, range_begin, range_end, dfa_state);
+            dfa.add_range_transition(
+                current_dfa_state,
+                char::try_from(range.start).unwrap(),
+                char::try_from(range.end).unwrap(),
+                dfa_state,
+            );
 
             work_list.push(closure);
         }

--- a/src/nfa_to_dfa.rs
+++ b/src/nfa_to_dfa.rs
@@ -7,7 +7,6 @@ use crate::nfa::StateIdx as NfaStateIdx;
 
 use std::collections::hash_map::Entry;
 use std::collections::BTreeSet;
-use std::convert::TryFrom;
 
 use fxhash::{FxHashMap, FxHashSet};
 
@@ -108,12 +107,7 @@ pub fn nfa_to_dfa<A: Clone>(nfa: &NFA<A>) -> DFA<A> {
             let closure: BTreeSet<NfaStateIdx> =
                 nfa.compute_state_closure(&state_set).into_iter().collect();
             let dfa_state = dfa_state_of_nfa_states(&mut dfa, &mut state_map, closure.clone());
-            dfa.add_range_transition(
-                current_dfa_state,
-                char::try_from(range.start).unwrap(),
-                char::try_from(range.end).unwrap(),
-                dfa_state,
-            );
+            dfa.add_range_transition(current_dfa_state, range.start, range.end, dfa_state);
 
             work_list.push(closure);
         }

--- a/src/range_map.rs
+++ b/src/range_map.rs
@@ -145,7 +145,7 @@ impl<A: Clone> RangeMap<A> {
                 continue;
             }
 
-            todo!()
+            unreachable!()
         }
     }
 

--- a/src/range_map.rs
+++ b/src/range_map.rs
@@ -27,6 +27,7 @@ impl<A> RangeMap<A> {
         }
     }
 
+    #[cfg(test)]
     fn iter_all(&self) -> impl Iterator<Item = &Range<A>> {
         self.ranges.iter()
     }
@@ -53,16 +54,8 @@ pub struct Range<A> {
 }
 
 impl<A> Range<A> {
-    fn new(start: u32, end: u32, value: A) -> Range<A> {
-        Range::with_values(start, end, vec![value])
-    }
-
     fn with_values(start: u32, end: u32, values: Vec<A>) -> Range<A> {
         Range { start, end, values }
-    }
-
-    fn add_value(&mut self, value: A) {
-        self.values.push(value)
     }
 
     fn add_values(&mut self, values: impl Iterator<Item = A>) {

--- a/src/range_map.rs
+++ b/src/range_map.rs
@@ -1,17 +1,24 @@
 use std::cmp::{max, min};
 
-/// A set of inclusive ranges, with insertion and iteration operations. Insertion allows
+/// A map of inclusive ranges, with insertion and iteration operations. Insertion allows
 /// overlapping ranges. When two ranges overlap, value of the overlapping parts is the union of
 /// values of the overlapping ranges.
-pub struct RangeSet<A> {
+#[derive(Debug)]
+pub struct RangeMap<A> {
     // NB. internally we don't have any overlaps. Overlapping ranges are split into smaller
     // non-overlapping ranges.
     ranges: Vec<Range<A>>,
 }
 
-impl<A> RangeSet<A> {
-    fn new() -> RangeSet<A> {
-        RangeSet {
+impl<A> Default for RangeMap<A> {
+    fn default() -> Self {
+        RangeMap::new()
+    }
+}
+
+impl<A> RangeMap<A> {
+    fn new() -> RangeMap<A> {
+        RangeMap {
             ranges: vec![Range {
                 start: 0,
                 end: usize::MAX,
@@ -20,8 +27,12 @@ impl<A> RangeSet<A> {
         }
     }
 
-    fn iter(&self) -> impl Iterator<Item = &Range<A>> {
+    fn iter_all(&self) -> impl Iterator<Item = &Range<A>> {
         self.ranges.iter()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &Range<A>> {
+        self.ranges.iter().filter(|r| !r.values.is_empty())
     }
 }
 
@@ -47,8 +58,8 @@ impl<A> Range<A> {
     }
 }
 
-impl<A: Clone> RangeSet<A> {
-    fn insert(&mut self, new_range_start: usize, new_range_end: usize, value: A) {
+impl<A: Clone> RangeMap<A> {
+    pub fn insert(&mut self, new_range_start: usize, new_range_end: usize, value: A) {
         // Scan all ranges and split as necessary
 
         let mut range_idx = 0;
@@ -140,13 +151,13 @@ fn to_tuple<A: Clone>(range: &Range<A>) -> (usize, usize, Vec<A>) {
 }
 
 #[cfg(test)]
-fn to_vec<A: Clone>(set: &RangeSet<A>) -> Vec<(usize, usize, Vec<A>)> {
-    set.iter().map(to_tuple).collect()
+fn to_vec<A: Clone>(map: &RangeMap<A>) -> Vec<(usize, usize, Vec<A>)> {
+    map.iter_all().map(to_tuple).collect()
 }
 
 #[test]
 fn add_non_overlapping() {
-    let mut ranges: RangeSet<u32> = RangeSet::new();
+    let mut ranges: RangeMap<u32> = RangeMap::new();
 
     ranges.insert(0, 10, 1);
     ranges.insert(20, 30, 0);
@@ -164,7 +175,7 @@ fn add_non_overlapping() {
 
 #[test]
 fn add_non_overlapping_reverse() {
-    let mut ranges: RangeSet<u32> = RangeSet::new();
+    let mut ranges: RangeMap<u32> = RangeMap::new();
 
     ranges.insert(20, 30, 0);
     ranges.insert(0, 10, 1);
@@ -182,7 +193,7 @@ fn add_non_overlapping_reverse() {
 
 #[test]
 fn add_overlapping_1() {
-    let mut ranges: RangeSet<u32> = RangeSet::new();
+    let mut ranges: RangeMap<u32> = RangeMap::new();
 
     ranges.insert(0, 10, 0);
     ranges.insert(10, 20, 1);
@@ -200,7 +211,7 @@ fn add_overlapping_1() {
 
 #[test]
 fn add_overlapping_1_reverse() {
-    let mut ranges: RangeSet<u32> = RangeSet::new();
+    let mut ranges: RangeMap<u32> = RangeMap::new();
 
     ranges.insert(10, 20, 1);
     ranges.insert(0, 10, 0);
@@ -218,7 +229,7 @@ fn add_overlapping_1_reverse() {
 
 #[test]
 fn add_overlapping_2() {
-    let mut ranges: RangeSet<u32> = RangeSet::new();
+    let mut ranges: RangeMap<u32> = RangeMap::new();
 
     ranges.insert(50, 100, 0);
 

--- a/src/range_map.rs
+++ b/src/range_map.rs
@@ -41,7 +41,7 @@ impl<A> RangeMap<A> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.ranges.is_empty()
+        self.iter().next().is_none()
     }
 }
 

--- a/src/range_map.rs
+++ b/src/range_map.rs
@@ -164,6 +164,81 @@ fn to_vec<A: Clone>(map: &RangeMap<A>) -> Vec<(u32, u32, Vec<A>)> {
     map.iter_all().map(to_tuple).collect()
 }
 
+#[cfg(test)]
+fn to_vec_skip_spaces<A: Clone>(map: &RangeMap<A>) -> Vec<(u32, u32, Vec<A>)> {
+    map.iter().map(to_tuple).collect()
+}
+
+#[test]
+fn overlap_left() {
+    let mut ranges: RangeMap<u32> = RangeMap::new();
+
+    ranges.insert(10, 20, 0);
+    ranges.insert(5, 15, 1);
+
+    assert_eq!(
+        to_vec_skip_spaces(&ranges),
+        vec![(5, 9, vec![1]), (10, 15, vec![0, 1]), (16, 20, vec![0])]
+    );
+
+    ranges.insert(5, 5, 2);
+
+    assert_eq!(
+        to_vec_skip_spaces(&ranges),
+        vec![
+            (5, 5, vec![1, 2]),
+            (6, 9, vec![1]),
+            (10, 15, vec![0, 1]),
+            (16, 20, vec![0]),
+        ]
+    );
+
+    let mut ranges: RangeMap<u32> = RangeMap::new();
+
+    ranges.insert(10, 20, 0);
+    ranges.insert(10, 15, 1);
+
+    assert_eq!(
+        to_vec_skip_spaces(&ranges),
+        vec![(10, 15, vec![0, 1]), (16, 20, vec![0])]
+    );
+}
+
+#[test]
+fn overlap_right() {
+    let mut ranges: RangeMap<u32> = RangeMap::new();
+
+    ranges.insert(5, 15, 1);
+    ranges.insert(10, 20, 0);
+
+    assert_eq!(
+        to_vec_skip_spaces(&ranges),
+        vec![(5, 9, vec![1]), (10, 15, vec![1, 0]), (16, 20, vec![0])]
+    );
+
+    ranges.insert(20, 20, 2);
+
+    assert_eq!(
+        to_vec_skip_spaces(&ranges),
+        vec![
+            (5, 9, vec![1]),
+            (10, 15, vec![1, 0]),
+            (16, 19, vec![0]),
+            (20, 20, vec![0, 2]),
+        ]
+    );
+
+    let mut ranges: RangeMap<u32> = RangeMap::new();
+
+    ranges.insert(10, 15, 1);
+    ranges.insert(10, 20, 0);
+
+    assert_eq!(
+        to_vec_skip_spaces(&ranges),
+        vec![(10, 15, vec![1, 0]), (16, 20, vec![0])]
+    );
+}
+
 #[test]
 fn add_non_overlapping() {
     let mut ranges: RangeMap<u32> = RangeMap::new();
@@ -290,5 +365,37 @@ fn add_overlapping_2() {
             (101, 110, vec![2]),
             (111, u32::MAX, vec![]),
         ]
+    );
+}
+
+#[test]
+fn large_range_multiple_overlaps() {
+    let mut ranges: RangeMap<u32> = RangeMap::new();
+
+    ranges.insert(10, 20, 0);
+    ranges.insert(21, 30, 1);
+    ranges.insert(5, 35, 2);
+
+    assert_eq!(
+        to_vec_skip_spaces(&ranges),
+        vec![
+            (5, 9, vec![2]),
+            (10, 20, vec![0, 2]),
+            (21, 30, vec![1, 2]),
+            (31, 35, vec![2]),
+        ]
+    );
+}
+
+#[test]
+fn overlap_middle() {
+    let mut ranges: RangeMap<u32> = RangeMap::new();
+
+    ranges.insert(10, 20, 0);
+    ranges.insert(15, 15, 1);
+
+    assert_eq!(
+        to_vec_skip_spaces(&ranges),
+        vec![(10, 14, vec![0]), (15, 15, vec![0, 1]), (16, 20, vec![0])]
     );
 }

--- a/src/range_map.rs
+++ b/src/range_map.rs
@@ -399,3 +399,13 @@ fn overlap_middle() {
         vec![(10, 14, vec![0]), (15, 15, vec![0, 1]), (16, 20, vec![0])]
     );
 }
+
+#[test]
+fn overlap_exact() {
+    let mut ranges: RangeMap<u32> = RangeMap::new();
+
+    ranges.insert(10, 20, 0);
+    ranges.insert(10, 20, 1);
+
+    assert_eq!(to_vec_skip_spaces(&ranges), vec![(10, 20, vec![0, 1])]);
+}

--- a/src/range_set.rs
+++ b/src/range_set.rs
@@ -1,0 +1,278 @@
+use std::cmp::{max, min};
+
+/// A set of inclusive ranges, with insertion and iteration operations. Insertion allows
+/// overlapping ranges. When two ranges overlap, value of the overlapping parts is the union of
+/// values of the overlapping ranges.
+pub struct RangeSet<A> {
+    // NB. internally we don't have any overlaps. Overlapping ranges are split into smaller
+    // non-overlapping ranges.
+    ranges: Vec<Range<A>>,
+}
+
+impl<A> RangeSet<A> {
+    fn new() -> RangeSet<A> {
+        RangeSet {
+            ranges: vec![Range {
+                start: 0,
+                end: usize::MAX,
+                values: vec![],
+            }],
+        }
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &Range<A>> {
+        self.ranges.iter()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Range<A> {
+    start: usize,
+    // Inclusive
+    end: usize,
+    values: Vec<A>,
+}
+
+impl<A> Range<A> {
+    fn new(start: usize, end: usize, value: A) -> Range<A> {
+        Range::with_values(start, end, vec![value])
+    }
+
+    fn with_values(start: usize, end: usize, values: Vec<A>) -> Range<A> {
+        Range { start, end, values }
+    }
+
+    fn add_value(&mut self, value: A) {
+        self.values.push(value)
+    }
+}
+
+impl<A: Clone> RangeSet<A> {
+    fn insert(&mut self, new_range_start: usize, new_range_end: usize, value: A) {
+        // Scan all ranges and split as necessary
+
+        let mut range_idx = 0;
+        while let Some(range) = self.ranges.get_mut(range_idx) {
+            if range.start > new_range_end {
+                break;
+            }
+
+            if range.end < new_range_start {
+                range_idx += 1;
+                continue;
+            }
+
+            // Handle the overlapping range in [range.start, range.end]
+            let overlap_start = max(range.start, new_range_start);
+            let overlap_end = min(range.end, new_range_end);
+
+            // Fast path for the special case when the entire range overlaps
+            if overlap_start == range.start && overlap_end == range.end {
+                range.add_value(value.clone());
+                range_idx += 1;
+                continue;
+            }
+
+            // Otherwise split from overlap_start, or overlap_end, or both
+            if overlap_start > range.start && overlap_end < range.end {
+                let old_values = range.values.clone();
+                let mut new_values = old_values.clone();
+                new_values.push(value.clone());
+
+                let old_end = range.end;
+                range.end = overlap_start - 1;
+
+                self.ranges.insert(
+                    range_idx + 1,
+                    Range::with_values(overlap_start, overlap_end, new_values),
+                );
+                self.ranges.insert(
+                    range_idx + 2,
+                    Range::with_values(overlap_end + 1, old_end, old_values),
+                );
+
+                range_idx += 3;
+                continue;
+            }
+
+            if overlap_start > range.start {
+                assert_eq!(overlap_end, range.end);
+
+                let mut new_values = range.values.clone();
+                new_values.push(value.clone());
+
+                range.end = overlap_start - 1;
+
+                self.ranges.insert(
+                    range_idx + 1,
+                    Range::with_values(overlap_start, overlap_end, new_values),
+                );
+
+                range_idx += 2;
+                continue;
+            }
+
+            if overlap_end < range.end {
+                assert_eq!(overlap_start, range.start);
+
+                let mut new_values = range.values.clone();
+                new_values.push(value.clone());
+
+                range.start = overlap_end + 1;
+
+                self.ranges.insert(
+                    range_idx,
+                    Range::with_values(overlap_start, overlap_end, new_values),
+                );
+
+                range_idx += 2;
+                continue;
+            }
+
+            todo!()
+        }
+    }
+}
+
+#[cfg(test)]
+fn to_tuple<A: Clone>(range: &Range<A>) -> (usize, usize, Vec<A>) {
+    (range.start, range.end, range.values.clone())
+}
+
+#[cfg(test)]
+fn to_vec<A: Clone>(set: &RangeSet<A>) -> Vec<(usize, usize, Vec<A>)> {
+    set.iter().map(to_tuple).collect()
+}
+
+#[test]
+fn add_non_overlapping() {
+    let mut ranges: RangeSet<u32> = RangeSet::new();
+
+    ranges.insert(0, 10, 1);
+    ranges.insert(20, 30, 0);
+
+    assert_eq!(
+        to_vec(&ranges),
+        vec![
+            (0, 10, vec![1]),
+            (11, 19, vec![]),
+            (20, 30, vec![0]),
+            (31, usize::MAX, vec![])
+        ]
+    );
+}
+
+#[test]
+fn add_non_overlapping_reverse() {
+    let mut ranges: RangeSet<u32> = RangeSet::new();
+
+    ranges.insert(20, 30, 0);
+    ranges.insert(0, 10, 1);
+
+    assert_eq!(
+        to_vec(&ranges),
+        vec![
+            (0, 10, vec![1]),
+            (11, 19, vec![]),
+            (20, 30, vec![0]),
+            (31, usize::MAX, vec![])
+        ]
+    );
+}
+
+#[test]
+fn add_overlapping_1() {
+    let mut ranges: RangeSet<u32> = RangeSet::new();
+
+    ranges.insert(0, 10, 0);
+    ranges.insert(10, 20, 1);
+
+    assert_eq!(
+        to_vec(&ranges),
+        vec![
+            (0, 9, vec![0]),
+            (10, 10, vec![0, 1]),
+            (11, 20, vec![1]),
+            (21, usize::MAX, vec![])
+        ]
+    );
+}
+
+#[test]
+fn add_overlapping_1_reverse() {
+    let mut ranges: RangeSet<u32> = RangeSet::new();
+
+    ranges.insert(10, 20, 1);
+    ranges.insert(0, 10, 0);
+
+    assert_eq!(
+        to_vec(&ranges),
+        vec![
+            (0, 9, vec![0]),
+            (10, 10, vec![1, 0]),
+            (11, 20, vec![1]),
+            (21, usize::MAX, vec![])
+        ]
+    );
+}
+
+#[test]
+fn add_overlapping_2() {
+    let mut ranges: RangeSet<u32> = RangeSet::new();
+
+    ranges.insert(50, 100, 0);
+
+    assert_eq!(
+        to_vec(&ranges),
+        vec![
+            (0, 49, vec![]),
+            (50, 100, vec![0]),
+            (101, usize::MAX, vec![]),
+        ]
+    );
+
+    ranges.insert(40, 60, 1);
+
+    assert_eq!(
+        to_vec(&ranges),
+        vec![
+            (0, 39, vec![]),
+            (40, 49, vec![1]),
+            (50, 60, vec![0, 1]),
+            (61, 100, vec![0]),
+            (101, usize::MAX, vec![]),
+        ]
+    );
+
+    ranges.insert(90, 110, 2);
+
+    assert_eq!(
+        to_vec(&ranges),
+        vec![
+            (0, 39, vec![]),
+            (40, 49, vec![1]),
+            (50, 60, vec![0, 1]),
+            (61, 89, vec![0]),
+            (90, 100, vec![0, 2]),
+            (101, 110, vec![2]),
+            (111, usize::MAX, vec![]),
+        ]
+    );
+
+    ranges.insert(70, 80, 3);
+
+    assert_eq!(
+        to_vec(&ranges),
+        vec![
+            (0, 39, vec![]),
+            (40, 49, vec![1]),
+            (50, 60, vec![0, 1]),
+            (61, 69, vec![0]),
+            (70, 80, vec![0, 3]),
+            (81, 89, vec![0]),
+            (90, 100, vec![0, 2]),
+            (101, 110, vec![2]),
+            (111, usize::MAX, vec![]),
+        ]
+    );
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -328,15 +328,24 @@ fn overlapping_ranges() {
     lexer! {
         Lexer -> usize;
 
+        ' ',
         ['a'-'b'] '1' = 1,
         ['a'-'c'] '2' = 2,
+        ['b'-'c'] '3' = 3,
+        'a' '4' = 4,
+        'b' '5' = 5,
+        'c' '6' = 6,
     }
 
-    let mut lexer = Lexer::new("a1");
-    assert_eq!(ignore_pos(lexer.next()), Some(Ok(1)));
-    assert_eq!(lexer.next(), None);
-
-    let mut lexer = Lexer::new("a2");
-    assert_eq!(ignore_pos(lexer.next()), Some(Ok(2)));
+    let mut lexer = Lexer::new("a1 b1 a2 b2 b3 c3 a4 b5 c6");
+    assert_eq!(ignore_pos(lexer.next()), Some(Ok(1))); // a1
+    assert_eq!(ignore_pos(lexer.next()), Some(Ok(1))); // b1
+    assert_eq!(ignore_pos(lexer.next()), Some(Ok(2))); // a2
+    assert_eq!(ignore_pos(lexer.next()), Some(Ok(2))); // b2
+    assert_eq!(ignore_pos(lexer.next()), Some(Ok(3))); // b3
+    assert_eq!(ignore_pos(lexer.next()), Some(Ok(3))); // c3
+    assert_eq!(ignore_pos(lexer.next()), Some(Ok(4))); // a4
+    assert_eq!(ignore_pos(lexer.next()), Some(Ok(5))); // b5
+    assert_eq!(ignore_pos(lexer.next()), Some(Ok(6))); // c6
     assert_eq!(lexer.next(), None);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -323,7 +323,6 @@ fn ignore_pos<A, E>(ret: Option<Result<(usize, A, usize), E>>) -> Option<Result<
     ret.map(|res| res.map(|(_, a, _)| a))
 }
 
-/*
 #[test]
 fn overlapping_ranges() {
     lexer! {
@@ -341,4 +340,3 @@ fn overlapping_ranges() {
     assert_eq!(ignore_pos(lexer.next()), Some(Ok(2)));
     assert_eq!(lexer.next(), None);
 }
-*/

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -318,3 +318,27 @@ fn rule_kind_fallible_with_lifetimes() {
     ));
     assert_eq!(lexer.next(), None);
 }
+
+fn ignore_pos<A, E>(ret: Option<Result<(usize, A, usize), E>>) -> Option<Result<A, E>> {
+    ret.map(|res| res.map(|(_, a, _)| a))
+}
+
+/*
+#[test]
+fn overlapping_ranges() {
+    lexer! {
+        Lexer -> usize;
+
+        ['a'-'b'] '1' = 1,
+        ['a'-'c'] '2' = 2,
+    }
+
+    let mut lexer = Lexer::new("a1");
+    assert_eq!(ignore_pos(lexer.next()), Some(Ok(1)));
+    assert_eq!(lexer.next(), None);
+
+    let mut lexer = Lexer::new("a2");
+    assert_eq!(ignore_pos(lexer.next()), Some(Ok(2)));
+    assert_eq!(lexer.next(), None);
+}
+*/


### PR DESCRIPTION
Previously we implicitly assumed that character ranges in a NFA/DFA state
cannot overlap, so for example, I cannot have rules `'0'-'9'` and `'5'-'9'` in
the NFA/DFA state. This is obviously incorrect, as reported in #2.

This patch introduces a "range map" that maps `u32` ranges to values. A range
can have multiple values (used in NFA-to-DFA conversion). When two ranges
overlap, the overlapping part has union of values of the overlapping ranges.

Using this type instead of `HashMap<(char, char), HashSet<NfaStateIdx>>`
automatically fixes the issue, as the handling of overlapping ranges
effectively implements switching to states of all of the overlapping ranges in
the NFA. So most of the code is just implementing the `RangeMap` type. Rest are
tests and replacing hash maps with `RangeMap`.

I also benchmarked this patch. For the Lua 5.1 lexer, this PR reduces compile
times 9%. Generated code is identical except orders of alternatives in or
patterns for ranges.

Fixes #2