### PR TITLE
Implement char exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+- New regex syntax `#` added for character set difference, e.g. `re1 # re2`
+  matches characters in `re1` that are not in `re2`. `re1` and `re2` need to be
+  "character sets", i.e. `*`, `+`, `?`, `"..."`, `|`, and concatenation are not
+  allowed.
+
 # 2021/11/30: 0.8.1
 
 New version published to fix broken README pages for lexgen and lexgen_util in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - New regex syntax `#` added for character set difference, e.g. `re1 # re2`
   matches characters in `re1` that are not in `re2`. `re1` and `re2` need to be
-  "character sets", i.e. `*`, `+`, `?`, `"..."`, `|`, and concatenation are not
+  "character sets", i.e. `*`, `+`, `?`, `"..."`, `$`, and concatenation are not
   allowed.
 
 # 2021/11/30: 0.8.1

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ of rules. The syntax is:
 - `<regex> | <regex>` for alternation: match the first one, or the second one.
 - `<regex> # <regex>` for difference: match characters in the first regex that
   are not in the second regex. Note that regexes on the left and right of `#`
-  should be "characters sets", i.e. `*`, `+`, `?`, `"..."`, `|`, and
+  should be "characters sets", i.e. `*`, `+`, `?`, `"..."`, `$`, and
   concatenation are not allowed. Variables that are bound to character sets are
   allowed.
 

--- a/README.md
+++ b/README.md
@@ -157,11 +157,17 @@ of rules. The syntax is:
 - `<regex>+` for one or more repetitions of `<regex>`
 - `<regex>?` for zero or one repetitions of `<regex>`
 - `<regex> <regex>` for concatenation
-- `<regex> | <regex>` for alternation (match the first one, or the second one)
+- `<regex> | <regex>` for alternation: match the first one, or the second one.
+- `<regex> # <regex>` for difference: match characters in the first regex that
+  are not in the second regex. Note that regexes on the left and right of `#`
+  should be "characters sets", i.e. `*`, `+`, `?`, `"..."`, `|`, and
+  concatenation are not allowed. Variables that are bound to character sets are
+  allowed.
 
 Binding powers (precedences), from higher to lower:
 
 - `*`, `+`, `?`
+- `#`
 - Concatenation
 - `|`
 

--- a/crates/lexgen/src/ast.rs
+++ b/crates/lexgen/src/ast.rs
@@ -120,24 +120,19 @@ pub enum Regex {
     Or(Box<Regex>, Box<Regex>),
     Any, // any character
     EndOfInput,
+
+    /// Difference, or exclusion: characters in the first regex, excluding characters in the second
+    /// regex.
+    Diff(Box<Regex>, Box<Regex>),
 }
 
 #[derive(Debug, Clone)]
-pub enum CharSet {
-    /// A variable. Needs to resolve to a `Regex::CharSet`.
-    Var(Var),
+pub struct CharSet(pub Vec<CharOrRange>);
 
-    /// A single character: `'a'`
+#[derive(Debug, Clone, Copy)]
+pub enum CharOrRange {
     Char(char),
-
-    /// A range of characters: `'a'-'z'`
     Range(char, char),
-
-    /// Alternation: `<charset> <charset>` (juxtaposition)
-    Or(Box<CharSet>, Box<CharSet>),
-
-    /// Exclusion: `<charset> # <charset>`
-    Diff(Box<CharSet>, Box<CharSet>),
 }
 
 /// Parses a regex terminated with: `=>` (used in rules with RHSs), `,` (used in rules without
@@ -200,8 +195,21 @@ fn parse_regex_2(input: ParseStream) -> syn::Result<Regex> {
     Ok(re)
 }
 
-// re_3 -> ( re_0 ) | $ | $x | $$x | _ | 'x' | "..." | [...]
+// re_3 -> re_4 | re_4 # re_4 (left associative)
 fn parse_regex_3(input: ParseStream) -> syn::Result<Regex> {
+    let mut re = parse_regex_4(input)?;
+
+    while input.peek(syn::token::Pound) {
+        let _ = input.parse::<syn::token::Pound>()?;
+        let re_2 = parse_regex_4(input)?;
+        re = Regex::Diff(Box::new(re), Box::new(re_2));
+    }
+
+    Ok(re)
+}
+
+// re_4 -> ( re_0 ) | $ | $x | $$x | _ | 'x' | "..." | [...]
+fn parse_regex_4(input: ParseStream) -> syn::Result<Regex> {
     if input.peek(syn::token::Paren) {
         let parenthesized;
         syn::parenthesized!(parenthesized in input);
@@ -239,52 +247,21 @@ fn parse_regex_3(input: ParseStream) -> syn::Result<Regex> {
 }
 
 fn parse_charset(input: ParseStream) -> syn::Result<CharSet> {
-    parse_charset_0(input)
-}
-
-// charset_0 -> charset_1 | charset_1 # charset_1
-fn parse_charset_0(input: ParseStream) -> syn::Result<CharSet> {
-    let mut charset = parse_charset_1(input)?;
-
-    while input.peek(syn::token::Pound) {
-        let _ = input.parse::<syn::token::Pound>()?;
-        let charset2 = parse_charset_1(input)?;
-        charset = CharSet::Diff(Box::new(charset), Box::new(charset2)); // left associative
+    let mut chars = vec![];
+    while !input.is_empty() {
+        chars.push(parse_char_or_range(input)?);
     }
-
-    Ok(charset)
+    Ok(CharSet(chars))
 }
 
-// charset_1 -> charset_2 | charset_2 charset_2 (alternation, juxtaposition)
-fn parse_charset_1(input: ParseStream) -> syn::Result<CharSet> {
-    let mut charset = parse_charset_2(input)?;
-
-    // Parse alternations
-    while input.peek(syn::LitChar) || input.peek(syn::token::Dollar) {
-        let charset2 = parse_charset_2(input)?;
-        charset = CharSet::Or(Box::new(charset), Box::new(charset2));
-    }
-
-    Ok(charset)
-}
-
-// charset_2 -> 'a' (char) | 'a'-'z' (char range) | $var
-fn parse_charset_2(input: ParseStream) -> syn::Result<CharSet> {
-    match input.parse::<syn::LitChar>() {
-        Err(_) => {
-            input.parse::<syn::token::Dollar>()?;
-            let ident = input.parse::<syn::Ident>()?;
-            Ok(CharSet::Var(Var(ident.to_string())))
-        }
-        Ok(char) => {
-            if input.peek(syn::token::Sub) {
-                let _ = input.parse::<syn::token::Sub>()?;
-                let char2 = input.parse::<syn::LitChar>()?;
-                Ok(CharSet::Range(char.value(), char2.value()))
-            } else {
-                Ok(CharSet::Char(char.value()))
-            }
-        }
+fn parse_char_or_range(input: ParseStream) -> syn::Result<CharOrRange> {
+    let char = input.parse::<syn::LitChar>()?.value();
+    if input.peek(syn::token::Sub) {
+        let _ = input.parse::<syn::token::Sub>()?;
+        let char2 = input.parse::<syn::LitChar>()?.value();
+        Ok(CharOrRange::Range(char, char2))
+    } else {
+        Ok(CharOrRange::Char(char))
     }
 }
 

--- a/crates/lexgen/src/ast.rs
+++ b/crates/lexgen/src/ast.rs
@@ -2,8 +2,10 @@
 
 use crate::semantic_action_table::{SemanticActionIdx, SemanticActionTable};
 
-use std::fmt;
 use syn::parse::ParseStream;
+
+use std::fmt;
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Var(pub String);
 

--- a/crates/lexgen/src/dfa.rs
+++ b/crates/lexgen/src/dfa.rs
@@ -179,7 +179,6 @@ impl<A> DFA<StateIdx, A> {
         } in other.states
         {
             let mut new_char_transitions: Map<char, StateIdx> = Default::default();
-            let mut new_range_transitions: RangeMap<StateIdx> = Default::default();
             let mut new_any_transition: Option<StateIdx> = None;
             let mut new_end_of_input_transition: Option<StateIdx> = None;
 
@@ -187,15 +186,8 @@ impl<A> DFA<StateIdx, A> {
                 new_char_transitions.insert(char, StateIdx(next.0 + n_current_states));
             }
 
-            // TODO: Quadratic code below
-            for range in range_transitions.iter() {
-                new_range_transitions.insert(
-                    range.start,
-                    range.end,
-                    StateIdx(range.value.0 + n_current_states),
-                    |_states_1, _states_2| panic!("Overlapping range transition in DFA::add_dfa"),
-                );
-            }
+            let new_range_transitions =
+                range_transitions.map(|state_idx| StateIdx(state_idx.0 + n_current_states));
 
             if let Some(next) = any_transition {
                 new_any_transition = Some(StateIdx(next.0 + n_current_states));

--- a/crates/lexgen/src/dfa.rs
+++ b/crates/lexgen/src/dfa.rs
@@ -109,7 +109,7 @@ impl<A> DFA<StateIdx, A> {
         self.states[next.0].predecessors.insert(state);
     }
 
-    pub fn set_range_transition(&mut self, state: StateIdx, range_map: RangeMap<StateIdx>) {
+    pub fn set_range_transitions(&mut self, state: StateIdx, range_map: RangeMap<StateIdx>) {
         assert!(self.states[state.0].range_transitions.is_empty());
 
         for range in range_map.iter() {
@@ -187,6 +187,7 @@ impl<A> DFA<StateIdx, A> {
                 new_char_transitions.insert(char, StateIdx(next.0 + n_current_states));
             }
 
+            // TODO: Quadratic code below
             for range in range_transitions.iter() {
                 new_range_transitions.insert(
                     range.start,

--- a/crates/lexgen/src/dfa.rs
+++ b/crates/lexgen/src/dfa.rs
@@ -109,23 +109,14 @@ impl<A> DFA<StateIdx, A> {
         self.states[next.0].predecessors.insert(state);
     }
 
-    pub fn add_range_transition(
-        &mut self,
-        state: StateIdx,
-        range_begin: u32,
-        range_end: u32,
-        next: StateIdx,
-    ) {
-        self.states[state.0].range_transitions.insert(
-            range_begin,
-            range_end,
-            next,
-            |_states_1, _states_2| {
-                panic!("Overlapping range transition in DFA::add_range_transition")
-            },
-        );
+    pub fn set_range_transition(&mut self, state: StateIdx, range_map: RangeMap<StateIdx>) {
+        assert!(self.states[state.0].range_transitions.is_empty());
 
-        self.states[next.0].predecessors.insert(state);
+        for range in range_map.iter() {
+            self.states[range.value.0].predecessors.insert(state);
+        }
+
+        self.states[state.0].range_transitions = range_map;
     }
 
     pub fn set_any_transition(&mut self, state: StateIdx, next: StateIdx) {

--- a/crates/lexgen/src/nfa.rs
+++ b/crates/lexgen/src/nfa.rs
@@ -125,23 +125,17 @@ impl<A> NFA<A> {
         );
     }
 
-    pub fn add_range_transitions(
-        &mut self,
-        state: StateIdx,
-        ranges: &RangeMap<()>,
-        next: StateIdx,
-    ) {
+    pub fn add_range_transitions(&mut self, state: StateIdx, ranges: RangeMap<()>, next: StateIdx) {
         let mut set: Set<StateIdx> = Default::default();
         set.insert(next);
-        // TODO: Quadratic behavior below, `RangeMap::insert` is O(number of ranges)
-        for range in ranges.iter() {
-            self.states[state.0].range_transitions.insert(
-                range.start as u32,
-                range.end as u32,
-                set.clone(),
-                |values_1, values_2| values_1.extend(values_2.into_iter()),
-            );
-        }
+
+        let ranges = ranges.map(|()| set.clone());
+
+        self.states[state.0]
+            .range_transitions
+            .insert_ranges(ranges.into_iter(), |values_1, values_2| {
+                values_1.extend(values_2.into_iter())
+            });
     }
 
     pub fn add_empty_transition(&mut self, state: StateIdx, next: StateIdx) {

--- a/crates/lexgen/src/nfa.rs
+++ b/crates/lexgen/src/nfa.rs
@@ -133,6 +133,7 @@ impl<A> NFA<A> {
     ) {
         let mut set: Set<StateIdx> = Default::default();
         set.insert(next);
+        // TODO: Quadratic behavior below, `RangeMap::insert` is O(number of ranges)
         for range in ranges.iter() {
             self.states[state.0].range_transitions.insert(
                 range.start as u32,

--- a/crates/lexgen/src/nfa.rs
+++ b/crates/lexgen/src/nfa.rs
@@ -111,15 +111,15 @@ impl<A> NFA<A> {
     pub fn add_range_transition(
         &mut self,
         state: StateIdx,
-        range_start: u32,
-        range_end: u32,
+        range_start: char,
+        range_end: char,
         next: StateIdx,
     ) {
         let mut set: Set<StateIdx> = Default::default();
         set.insert(next);
         self.states[state.0].range_transitions.insert(
-            range_start,
-            range_end,
+            range_start as u32,
+            range_end as u32,
             set,
             |values_1, values_2| values_1.extend(values_2.into_iter()),
         );
@@ -133,8 +133,6 @@ impl<A> NFA<A> {
     ) {
         let mut set: Set<StateIdx> = Default::default();
         set.insert(next);
-
-        // TODO: Quadratic behavior below, `RangeMap::insert` is O(number of ranges).
         for range in ranges.iter() {
             self.states[state.0].range_transitions.insert(
                 range.start as u32,

--- a/crates/lexgen/src/nfa.rs
+++ b/crates/lexgen/src/nfa.rs
@@ -111,15 +111,15 @@ impl<A> NFA<A> {
     pub fn add_range_transition(
         &mut self,
         state: StateIdx,
-        range_start: char,
-        range_end: char,
+        range_start: u32,
+        range_end: u32,
         next: StateIdx,
     ) {
         let mut set: Set<StateIdx> = Default::default();
         set.insert(next);
         self.states[state.0].range_transitions.insert(
-            range_start as u32,
-            range_end as u32,
+            range_start,
+            range_end,
             set,
             |values_1, values_2| values_1.extend(values_2.into_iter()),
         );
@@ -133,6 +133,8 @@ impl<A> NFA<A> {
     ) {
         let mut set: Set<StateIdx> = Default::default();
         set.insert(next);
+
+        // TODO: Quadratic behavior below, `RangeMap::insert` is O(number of ranges).
         for range in ranges.iter() {
             self.states[state.0].range_transitions.insert(
                 range.start as u32,

--- a/crates/lexgen/src/nfa.rs
+++ b/crates/lexgen/src/nfa.rs
@@ -111,18 +111,36 @@ impl<A> NFA<A> {
     pub fn add_range_transition(
         &mut self,
         state: StateIdx,
-        range_begin: char,
+        range_start: char,
         range_end: char,
         next: StateIdx,
     ) {
         let mut set: Set<StateIdx> = Default::default();
         set.insert(next);
         self.states[state.0].range_transitions.insert(
-            range_begin as u32,
+            range_start as u32,
             range_end as u32,
             set,
             |values_1, values_2| values_1.extend(values_2.into_iter()),
         );
+    }
+
+    pub fn add_range_transitions(
+        &mut self,
+        state: StateIdx,
+        ranges: &RangeMap<()>,
+        next: StateIdx,
+    ) {
+        let mut set: Set<StateIdx> = Default::default();
+        set.insert(next);
+        for range in ranges.iter() {
+            self.states[state.0].range_transitions.insert(
+                range.start as u32,
+                range.end as u32,
+                set.clone(),
+                |values_1, values_2| values_1.extend(values_2.into_iter()),
+            );
+        }
     }
 
     pub fn add_empty_transition(&mut self, state: StateIdx, next: StateIdx) {

--- a/crates/lexgen/src/nfa_to_dfa.rs
+++ b/crates/lexgen/src/nfa_to_dfa.rs
@@ -134,7 +134,7 @@ pub fn nfa_to_dfa<A: Clone>(nfa: &NFA<A>) -> DFA<DfaStateIdx, A> {
             work_list.push(closure);
         }
 
-        dfa.set_range_transition(
+        dfa.set_range_transitions(
             current_dfa_state,
             RangeMap::from_non_overlapping_sorted_ranges(dfa_range_transitions),
         );

--- a/crates/lexgen/src/range_map.rs
+++ b/crates/lexgen/src/range_map.rs
@@ -30,6 +30,21 @@ impl<A> RangeMap<A> {
         RangeMap { ranges: vec![] }
     }
 
+    /// Create a range map from given non-overlapping and sorted ranges. These properties
+    /// (non-overlapping, sorted) are checked in debug mode but not in release mode.
+    ///
+    /// O(1)
+    pub fn from_non_overlapping_sorted_ranges(ranges: Vec<Range<A>>) -> RangeMap<A> {
+        #[cfg(debug_assertions)]
+        for ranges in ranges.windows(2) {
+            let range1 = &ranges[0];
+            let range2 = &ranges[1];
+            assert!(range1.end < range2.start);
+        }
+
+        RangeMap { ranges }
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &Range<A>> {
         self.ranges.iter()
     }

--- a/crates/lexgen/src/range_map.rs
+++ b/crates/lexgen/src/range_map.rs
@@ -71,6 +71,23 @@ impl<A> RangeMap<A> {
                 .collect(),
         }
     }
+
+    pub fn map<F, B>(self, mut f: F) -> RangeMap<B>
+    where
+        F: FnMut(A) -> B,
+    {
+        RangeMap {
+            ranges: self
+                .ranges
+                .into_iter()
+                .map(|Range { start, end, value }| Range {
+                    start,
+                    end,
+                    value: f(value),
+                })
+                .collect(),
+        }
+    }
 }
 
 impl<A> Range<A> {

--- a/crates/lexgen/src/range_map.rs
+++ b/crates/lexgen/src/range_map.rs
@@ -45,6 +45,10 @@ impl<A> RangeMap<A> {
         RangeMap { ranges }
     }
 
+    pub fn len(&self) -> usize {
+        self.ranges.len()
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &Range<A>> {
         self.ranges.iter()
     }

--- a/crates/lexgen/src/range_map.rs
+++ b/crates/lexgen/src/range_map.rs
@@ -26,7 +26,7 @@ impl<A> Default for RangeMap<A> {
 }
 
 impl<A> RangeMap<A> {
-    fn new() -> RangeMap<A> {
+    pub fn new() -> RangeMap<A> {
         RangeMap { ranges: vec![] }
     }
 
@@ -164,7 +164,6 @@ impl<A: Clone> RangeMap<A> {
         self.ranges = new_ranges;
     }
 
-    #[cfg(test)]
     pub fn remove_ranges<B>(&mut self, other: &RangeMap<B>) {
         let old_ranges = replace(&mut self.ranges, vec![]);
         let mut new_ranges: Vec<Range<A>> = Vec::with_capacity(old_ranges.len());

--- a/crates/lexgen/src/range_map.rs
+++ b/crates/lexgen/src/range_map.rs
@@ -164,6 +164,7 @@ impl<A: Clone> RangeMap<A> {
         self.ranges = new_ranges;
     }
 
+    /// O(N+M) where N is the number of current ranges and M number of removed ranges.
     pub fn remove_ranges<B>(&mut self, other: &RangeMap<B>) {
         let old_ranges = replace(&mut self.ranges, vec![]);
         let mut new_ranges: Vec<Range<A>> = Vec::with_capacity(old_ranges.len());

--- a/crates/lexgen/src/regex_to_nfa.rs
+++ b/crates/lexgen/src/regex_to_nfa.rs
@@ -142,6 +142,7 @@ fn regex_to_range_map(bindings: &Map<Var, Regex>, re: &Regex) -> RangeMap<()> {
 
             let builtin = get_builtin_regex(builtin);
 
+            // TODO: Quadratic behavior below, `RangeMap::insert` is O(number of ranges)
             for (range_start, range_end) in builtin.get_ranges() {
                 map.insert(*range_start, *range_end, (), merge_values);
             }
@@ -167,6 +168,7 @@ fn regex_to_range_map(bindings: &Map<Var, Regex>, re: &Regex) -> RangeMap<()> {
         Regex::CharSet(char_set) => {
             let mut map = RangeMap::new();
 
+            // TODO: Quadratic behavior below, `RangeMap::insert` is O(number of ranges)
             for char_or_range in char_set.0.iter() {
                 match char_or_range {
                     CharOrRange::Char(char) => {
@@ -201,6 +203,7 @@ fn regex_to_range_map(bindings: &Map<Var, Regex>, re: &Regex) -> RangeMap<()> {
             let mut map1 = regex_to_range_map(bindings, re1);
             let map2 = regex_to_range_map(bindings, re2);
 
+            // TODO: Quadratic behavior below, `RangeMap::insert` is O(number of ranges)
             for range_2 in map2.into_iter() {
                 map1.insert(range_2.start, range_2.end, (), merge_values);
             }

--- a/crates/lexgen/src/regex_to_nfa.rs
+++ b/crates/lexgen/src/regex_to_nfa.rs
@@ -210,7 +210,7 @@ fn regex_to_range_map(bindings: &Map<Var, Regex>, re: &Regex) -> RangeMap<()> {
 
         Regex::Any => {
             let mut map = RangeMap::new();
-            map.insert(0, u32::MAX, (), merge_values);
+            map.insert(0, char::MAX as u32, (), merge_values);
             map
         }
 

--- a/crates/lexgen/src/regex_to_nfa.rs
+++ b/crates/lexgen/src/regex_to_nfa.rs
@@ -1,7 +1,8 @@
-use crate::ast::{CharOrRange, Regex, Var};
-use crate::builtin::BUILTIN_RANGES;
+use crate::ast::{Builtin, CharOrRange, Regex, Var};
+use crate::builtin::{BuiltinCharRange, BUILTIN_RANGES};
 use crate::collections::Map;
 use crate::nfa::{StateIdx, NFA};
+use crate::range_map::RangeMap;
 
 use std::convert::TryFrom;
 
@@ -14,16 +15,7 @@ pub fn add_re<A>(
 ) {
     match re {
         Regex::Builtin(builtin_name) => {
-            let builtin = BUILTIN_RANGES.iter().find_map(|(name, builtin_)| {
-                if *name == builtin_name.0 {
-                    Some(*builtin_)
-                } else {
-                    None
-                }
-            });
-
-            let builtin =
-                builtin.unwrap_or_else(|| panic!("Unknown builtin regex: {}", builtin_name.0));
+            let builtin = get_builtin_regex(builtin_name);
 
             for (range_start, range_end) in builtin.get_ranges() {
                 nfa.add_range_transition(
@@ -122,5 +114,115 @@ pub fn add_re<A>(
         Regex::EndOfInput => {
             nfa.add_end_of_input_transition(current, cont);
         }
+
+        Regex::Diff(_, _) => {
+            let map = regex_to_range_map(bindings, re);
+            nfa.add_range_transitions(current, &map, cont);
+        }
     }
 }
+
+fn get_builtin_regex(builtin: &Builtin) -> BuiltinCharRange {
+    BUILTIN_RANGES
+        .iter()
+        .find_map(|(name, builtin_)| {
+            if *name == builtin.0 {
+                Some(*builtin_)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| panic!("Unknown builtin regex: {}", builtin.0))
+}
+
+fn regex_to_range_map(bindings: &Map<Var, Regex>, re: &Regex) -> RangeMap<()> {
+    match re {
+        Regex::Builtin(builtin) => {
+            let mut map = RangeMap::new();
+
+            let builtin = get_builtin_regex(builtin);
+
+            for (range_start, range_end) in builtin.get_ranges() {
+                map.insert(*range_start, *range_end, (), merge_values);
+            }
+            map
+        }
+
+        Regex::Var(var) => {
+            let re = bindings
+                .get(var)
+                .unwrap_or_else(|| panic!("Unbound variable {:?}", var.0));
+
+            regex_to_range_map(bindings, re)
+        }
+
+        Regex::Char(char) => {
+            let mut map = RangeMap::new();
+            map.insert(*char as u32, *char as u32, (), merge_values);
+            map
+        }
+
+        Regex::String(_) => panic!("strings cannot be used in char sets (`#`)"),
+
+        Regex::CharSet(char_set) => {
+            let mut map = RangeMap::new();
+
+            for char_or_range in char_set.0.iter() {
+                match char_or_range {
+                    CharOrRange::Char(char) => {
+                        map.insert(*char as u32, *char as u32, (), merge_values);
+                    }
+                    CharOrRange::Range(start, end) => {
+                        map.insert(*start as u32, *end as u32, (), merge_values);
+                    }
+                }
+            }
+
+            map
+        }
+
+        Regex::ZeroOrMore(_) => {
+            panic!("`*` cannot be used in char sets (`#`)");
+        }
+
+        Regex::OneOrMore(_) => {
+            panic!("`+` cannot be used in char sets (`#`)");
+        }
+
+        Regex::ZeroOrOne(_) => {
+            panic!("`?` cannot be used in char sets (`#`)");
+        }
+
+        Regex::Concat(_, _) => {
+            panic!("concatenation (`<re1> <re2>`) cannot be used in char sets (`#`)");
+        }
+
+        Regex::Or(re1, re2) => {
+            let mut map1 = regex_to_range_map(bindings, re1);
+            let map2 = regex_to_range_map(bindings, re2);
+
+            for range_2 in map2.into_iter() {
+                map1.insert(range_2.start, range_2.end, (), merge_values);
+            }
+
+            map1
+        }
+
+        Regex::Any => {
+            let mut map = RangeMap::new();
+            map.insert(0, u32::MAX, (), merge_values);
+            map
+        }
+
+        Regex::EndOfInput => panic!("`$` cannot be used in char sets (`#`)"),
+
+        Regex::Diff(re1, re2) => {
+            let mut map1 = regex_to_range_map(bindings, re1);
+            let map2 = regex_to_range_map(bindings, re2);
+            map1.remove_ranges(&map2);
+            map1
+        }
+    }
+}
+
+fn merge_values(_val1: &mut (), _val2: ()) {}

--- a/crates/lexgen/src/regex_to_nfa.rs
+++ b/crates/lexgen/src/regex_to_nfa.rs
@@ -1,10 +1,8 @@
-use crate::ast::{Builtin, CharOrRange, Regex, Var};
+use crate::ast::{Builtin, CharSet, Regex, Var};
 use crate::builtin::{BuiltinCharRange, BUILTIN_RANGES};
 use crate::collections::Map;
 use crate::nfa::{StateIdx, NFA};
 use crate::range_map::RangeMap;
-
-use std::convert::TryFrom;
 
 pub fn add_re<A>(
     nfa: &mut NFA<A>,
@@ -18,12 +16,7 @@ pub fn add_re<A>(
             let builtin = get_builtin_regex(builtin_name);
 
             for (range_start, range_end) in builtin.get_ranges() {
-                nfa.add_range_transition(
-                    current,
-                    char::try_from(*range_start).unwrap(),
-                    char::try_from(*range_end).unwrap(),
-                    cont,
-                );
+                nfa.add_range_transition(current, *range_start, *range_end, cont);
             }
         }
 
@@ -53,17 +46,9 @@ pub fn add_re<A>(
             }
         }
 
-        Regex::CharSet(set) => {
-            for char in &set.0 {
-                match char {
-                    CharOrRange::Char(char) => {
-                        nfa.add_char_transition(current, *char, cont);
-                    }
-                    CharOrRange::Range(range_start, range_end) => {
-                        nfa.add_range_transition(current, *range_start, *range_end, cont);
-                    }
-                }
-            }
+        Regex::CharSet(charset) => {
+            let range_map = charset_to_range_map(bindings, charset);
+            nfa.add_range_transitions(current, &range_map, cont);
         }
 
         Regex::ZeroOrMore(re) => {
@@ -114,11 +99,6 @@ pub fn add_re<A>(
         Regex::EndOfInput => {
             nfa.add_end_of_input_transition(current, cont);
         }
-
-        Regex::Diff(_, _) => {
-            let map = regex_to_range_map(bindings, re);
-            nfa.add_range_transitions(current, &map, cont);
-        }
     }
 }
 
@@ -135,19 +115,52 @@ fn get_builtin_regex(builtin: &Builtin) -> BuiltinCharRange {
         .unwrap_or_else(|| panic!("Unknown builtin regex: {}", builtin.0))
 }
 
-fn regex_to_range_map(bindings: &Map<Var, Regex>, re: &Regex) -> RangeMap<()> {
-    match re {
-        Regex::Builtin(builtin) => {
+fn charset_to_range_map(bindings: &Map<Var, Regex>, charset: &CharSet) -> RangeMap<()> {
+    match charset {
+        CharSet::Var(var) => {
+            let re = bindings
+                .get(var)
+                .unwrap_or_else(|| panic!("Unbound variable {:?}", var.0));
+
+            regex_to_range_map(bindings, re)
+        }
+
+        CharSet::Char(char) => {
             let mut map = RangeMap::new();
-
-            let builtin = get_builtin_regex(builtin);
-
-            for (range_start, range_end) in builtin.get_ranges() {
-                map.insert(*range_start, *range_end, (), merge_values);
-            }
+            map.insert(*char as u32, *char as u32, (), merge_values);
             map
         }
 
+        CharSet::Range(range_start, range_end) => {
+            let mut map = RangeMap::new();
+            map.insert(*range_start as u32, *range_end as u32, (), merge_values);
+            map
+        }
+
+        CharSet::Or(charset1, charset2) => {
+            let mut map1 = charset_to_range_map(bindings, charset1);
+            let map2 = charset_to_range_map(bindings, charset2);
+
+            for range in map2.into_iter() {
+                map1.insert(range.start, range.end, range.value, merge_values);
+            }
+
+            map1
+        }
+
+        CharSet::Diff(charset1, charset2) => {
+            let mut map1 = charset_to_range_map(bindings, charset1);
+            let map2 = charset_to_range_map(bindings, charset2);
+
+            map1.remove_ranges(&map2);
+
+            map1
+        }
+    }
+}
+
+fn regex_to_range_map(bindings: &Map<Var, Regex>, re: &Regex) -> RangeMap<()> {
+    match re {
         Regex::Var(var) => {
             let re = bindings
                 .get(var)
@@ -156,72 +169,31 @@ fn regex_to_range_map(bindings: &Map<Var, Regex>, re: &Regex) -> RangeMap<()> {
             regex_to_range_map(bindings, re)
         }
 
-        Regex::Char(char) => {
-            let mut map = RangeMap::new();
-            map.insert(*char as u32, *char as u32, (), merge_values);
-            map
-        }
+        Regex::Builtin(builtin_name) => {
+            let builtin = get_builtin_regex(builtin_name);
 
-        Regex::String(_) => panic!("strings cannot be used in char sets (`#`)"),
-
-        Regex::CharSet(char_set) => {
             let mut map = RangeMap::new();
 
-            for char_or_range in char_set.0.iter() {
-                match char_or_range {
-                    CharOrRange::Char(char) => {
-                        map.insert(*char as u32, *char as u32, (), merge_values);
-                    }
-                    CharOrRange::Range(start, end) => {
-                        map.insert(*start as u32, *end as u32, (), merge_values);
-                    }
-                }
+            // TODO: Quadratic behavior below, `RangeMap::insert` is O(number of ranges).
+            for (range_start, range_end) in builtin.get_ranges() {
+                map.insert(*range_start, *range_end, (), merge_values);
             }
 
             map
         }
 
-        Regex::ZeroOrMore(_) => {
-            panic!("`*` cannot be used in char sets (`#`)");
-        }
+        Regex::CharSet(charset) => charset_to_range_map(bindings, charset),
 
-        Regex::OneOrMore(_) => {
-            panic!("`+` cannot be used in char sets (`#`)");
-        }
-
-        Regex::ZeroOrOne(_) => {
-            panic!("`?` cannot be used in char sets (`#`)");
-        }
-
-        Regex::Concat(_, _) => {
-            panic!("concatenation (`<re1> <re2>`) cannot be used in char sets (`#`)");
-        }
-
-        Regex::Or(re1, re2) => {
-            let mut map1 = regex_to_range_map(bindings, re1);
-            let map2 = regex_to_range_map(bindings, re2);
-
-            for range_2 in map2.into_iter() {
-                map1.insert(range_2.start, range_2.end, (), merge_values);
-            }
-
-            map1
-        }
-
-        Regex::Any => {
-            let mut map = RangeMap::new();
-            map.insert(0, char::MAX as u32, (), merge_values);
-            map
-        }
-
-        Regex::EndOfInput => panic!("`$` cannot be used in char sets (`#`)"),
-
-        Regex::Diff(re1, re2) => {
-            let mut map1 = regex_to_range_map(bindings, re1);
-            let map2 = regex_to_range_map(bindings, re2);
-            map1.remove_ranges(&map2);
-            map1
-        }
+        // TODO: Some of the cases below could be handled
+        Regex::Char(char) => panic!("Regex {:?} cannot be converted to charset", char),
+        Regex::String(str) => panic!("Regex {:?} cannot be converted to charset", str),
+        Regex::ZeroOrMore(_) => panic!("Regex with '*' cannot be converted to charset"),
+        Regex::OneOrMore(_) => panic!("Regex with '+' cannot be converted to charset"),
+        Regex::ZeroOrOne(_) => panic!("Regex with '?' cannot be converted to charset"),
+        Regex::Concat(_, _) => panic!("Regex with concatenation cannot be converted to charset"),
+        Regex::Or(_, _) => panic!("Regex with `|` cannot be converted to charset"),
+        Regex::Any => panic!("Regex '_' cannot be converted to charset"),
+        Regex::EndOfInput => panic!("Regex '$' cannot be converted to charset"),
     }
 }
 

--- a/crates/lexgen/src/regex_to_nfa.rs
+++ b/crates/lexgen/src/regex_to_nfa.rs
@@ -206,10 +206,7 @@ fn regex_to_range_map(bindings: &Map<Var, Regex>, re: &Regex) -> RangeMap<()> {
             let mut map1 = regex_to_range_map(bindings, re1);
             let map2 = regex_to_range_map(bindings, re2);
 
-            // TODO: Quadratic behavior below, `RangeMap::insert` is O(number of ranges)
-            for range_2 in map2.into_iter() {
-                map1.insert(range_2.start, range_2.end, (), merge_values);
-            }
+            map1.insert_ranges(map2.into_iter(), merge_values);
 
             map1
         }

--- a/crates/lexgen/src/tests.rs
+++ b/crates/lexgen/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::ast::{CharOrRange, CharSet, Regex, Var};
+use crate::ast::{CharSet, Regex, Var};
 use crate::collections::Map;
 use crate::nfa::simulate::{ErrorLoc, Matches};
 use crate::nfa::NFA;
@@ -133,10 +133,11 @@ fn simulate_string() {
 
 #[test]
 fn simulate_char_set_char() {
-    let re = Regex::CharSet(CharSet(vec![
-        CharOrRange::Char('a'),
-        CharOrRange::Char('b'),
-    ]));
+    let re = Regex::CharSet(CharSet::Or(
+        Box::new(CharSet::Char('a')),
+        Box::new(CharSet::Char('b')),
+    ));
+
     let mut nfa: NFA<usize> = NFA::new();
     nfa.add_regex(&Default::default(), &re, 1);
 
@@ -153,11 +154,14 @@ fn simulate_char_set_char() {
 
 #[test]
 fn simulate_char_set_range() {
-    let re = Regex::CharSet(CharSet(vec![
-        CharOrRange::Char('a'),
-        CharOrRange::Char('b'),
-        CharOrRange::Range('0', '9'),
-    ]));
+    let re = Regex::CharSet(CharSet::Or(
+        Box::new(CharSet::Or(
+            Box::new(CharSet::Char('a')),
+            Box::new(CharSet::Char('b')),
+        )),
+        Box::new(CharSet::Range('0', '9')),
+    ));
+
     let mut nfa: NFA<usize> = NFA::new();
     nfa.add_regex(&Default::default(), &re, 1);
 
@@ -294,7 +298,7 @@ fn multiple_accepting_states_2() {
         Box::new(Regex::OneOrMore(Box::new(Regex::Char('a')))),
         Box::new(Regex::Char('b')),
     );
-    let re2 = Regex::CharSet(CharSet(vec![CharOrRange::Range('0', '9')]));
+    let re2 = Regex::CharSet(CharSet::Range('0', '9'));
     let mut nfa: NFA<usize> = NFA::new();
     nfa.add_regex(&Default::default(), &re1, 1);
     nfa.add_regex(&Default::default(), &re2, 2);
@@ -315,17 +319,23 @@ fn simulate_variables() {
     let mut bindings: Map<Var, Regex> = Default::default();
     bindings.insert(
         Var("initial".to_owned()),
-        Regex::CharSet(CharSet(vec![CharOrRange::Range('a', 'z')])),
+        Regex::CharSet(CharSet::Range('a', 'z')),
     );
     bindings.insert(
         Var("subsequent".to_owned()),
-        Regex::CharSet(CharSet(vec![
-            CharOrRange::Range('a', 'z'),
-            CharOrRange::Range('A', 'Z'),
-            CharOrRange::Range('0', '9'),
-            CharOrRange::Char('-'),
-            CharOrRange::Char('_'),
-        ])),
+        Regex::CharSet(CharSet::Or(
+            Box::new(CharSet::Or(
+                Box::new(CharSet::Or(
+                    Box::new(CharSet::Or(
+                        Box::new(CharSet::Range('a', 'a')),
+                        Box::new(CharSet::Range('A', 'Z')),
+                    )),
+                    Box::new(CharSet::Range('0', '9')),
+                )),
+                Box::new(CharSet::Char('-')),
+            )),
+            Box::new(CharSet::Char('_')),
+        )),
     );
     let re = Regex::Concat(
         Box::new(Regex::Var(Var("initial".to_owned()))),
@@ -512,9 +522,7 @@ fn range_and_char_confusion() {
     nfa.add_regex(&Default::default(), &Regex::String("ab".to_owned()), 1);
     nfa.add_regex(
         &Default::default(),
-        &Regex::OneOrMore(Box::new(Regex::CharSet(CharSet(vec![CharOrRange::Range(
-            'a', 'z',
-        )])))),
+        &Regex::OneOrMore(Box::new(Regex::CharSet(CharSet::Range('a', 'z')))),
         2,
     );
 
@@ -531,7 +539,7 @@ fn overlapping_ranges() {
     nfa.add_regex(
         &Default::default(),
         &Regex::Concat(
-            Box::new(Regex::CharSet(CharSet(vec![CharOrRange::Range('a', 'b')]))),
+            Box::new(Regex::CharSet(CharSet::Range('a', 'b'))),
             Box::new(Regex::Char('1')),
         ),
         1,
@@ -539,7 +547,7 @@ fn overlapping_ranges() {
     nfa.add_regex(
         &Default::default(),
         &Regex::Concat(
-            Box::new(Regex::CharSet(CharSet(vec![CharOrRange::Range('a', 'c')]))),
+            Box::new(Regex::CharSet(CharSet::Range('a', 'c'))),
             Box::new(Regex::Char('2')),
         ),
         2,

--- a/crates/lexgen/tests/tests.rs
+++ b/crates/lexgen/tests/tests.rs
@@ -1,7 +1,7 @@
 mod test_utils;
 
 use lexgen::lexer;
-use lexgen_util::Loc;
+use lexgen_util::{LexerError, Loc};
 use test_utils::{loc, next};
 
 use std::convert::TryFrom;
@@ -1065,4 +1065,29 @@ fn diff_3() {
     let mut lexer = Lexer::new("'a'");
     assert_eq!(next(&mut lexer), Some(Ok("'a'")));
     assert_eq!(next(&mut lexer), None);
+}
+
+#[test]
+fn diff_4() {
+    lexer! {
+        Lexer -> &'input str;
+
+        "//" (_ # '\n')* $? => |lexer| {
+            let match_ = lexer.match_();
+            lexer.return_(match_)
+        },
+    }
+
+    let mut lexer = Lexer::new("// asdf");
+    assert_eq!(next(&mut lexer), Some(Ok("// asdf")));
+    assert_eq!(next(&mut lexer), None);
+
+    let mut lexer = Lexer::new("// asdf\n");
+    assert_eq!(next(&mut lexer), Some(Ok("// asdf")));
+    assert_eq!(
+        next(&mut lexer),
+        Some(Err(LexerError::InvalidToken {
+            location: loc(0, 7, 7)
+        }))
+    );
 }

--- a/crates/lexgen/tests/tests.rs
+++ b/crates/lexgen/tests/tests.rs
@@ -997,7 +997,7 @@ fn diff_1() {
     lexer! {
         Lexer -> &'input str;
 
-        ['0'-'9' # '3'-'7'] => |lexer| {
+        ['0'-'9'] # ['3'-'7'] => |lexer| {
             let match_ = lexer.match_();
             lexer.return_(match_)
         },
@@ -1020,13 +1020,12 @@ fn diff_1() {
     assert!(matches!(next(&mut lexer), None));
 }
 
-/*
 #[test]
 fn diff_2() {
     lexer! {
         Lexer -> &'input str;
 
-        [_ # 'a'] => |lexer| {
+        _ # 'a' => |lexer| {
             let match_ = lexer.match_();
             lexer.return_(match_)
         },
@@ -1040,4 +1039,3 @@ fn diff_2() {
     assert!(matches!(next(&mut lexer), Some(Err(_))));
     assert!(matches!(next(&mut lexer), None));
 }
-*/

--- a/crates/lexgen/tests/tests.rs
+++ b/crates/lexgen/tests/tests.rs
@@ -997,7 +997,7 @@ fn diff_1() {
     lexer! {
         Lexer -> &'input str;
 
-        ['0'-'9'] # ['3'-'7'] => |lexer| {
+        ['0'-'9' # '3'-'7'] => |lexer| {
             let match_ = lexer.match_();
             lexer.return_(match_)
         },
@@ -1020,12 +1020,13 @@ fn diff_1() {
     assert!(matches!(next(&mut lexer), None));
 }
 
+/*
 #[test]
 fn diff_2() {
     lexer! {
         Lexer -> &'input str;
 
-        _ # 'a' => |lexer| {
+        [_ # 'a'] => |lexer| {
             let match_ = lexer.match_();
             lexer.return_(match_)
         },
@@ -1039,3 +1040,4 @@ fn diff_2() {
     assert!(matches!(next(&mut lexer), Some(Err(_))));
     assert!(matches!(next(&mut lexer), None));
 }
+*/

--- a/crates/lexgen/tests/tests.rs
+++ b/crates/lexgen/tests/tests.rs
@@ -997,7 +997,9 @@ fn diff_1() {
     lexer! {
         Lexer -> &'input str;
 
-        ['0'-'9'] # ['3'-'7'] => |lexer| {
+        let exclude = ['3'-'7'];
+
+        ['0'-'9'] # $exclude => |lexer| {
             let match_ = lexer.match_();
             lexer.return_(match_)
         },
@@ -1038,4 +1040,29 @@ fn diff_2() {
     let mut lexer = Lexer::new("a");
     assert!(matches!(next(&mut lexer), Some(Err(_))));
     assert!(matches!(next(&mut lexer), None));
+}
+
+#[test]
+fn diff_3() {
+    lexer! {
+        Lexer -> &'input str;
+
+        "'" (_ # ('\t' | '\n' | '\\' | '\'')) "'" => |lexer| {
+            let match_ = lexer.match_();
+            lexer.return_(match_)
+        },
+    }
+
+    let mut lexer = Lexer::new("''");
+    assert!(matches!(next(&mut lexer), Some(Err(_))));
+
+    let mut lexer = Lexer::new("'''");
+    assert!(matches!(next(&mut lexer), Some(Err(_))));
+
+    let mut lexer = Lexer::new("'\t'");
+    assert!(matches!(next(&mut lexer), Some(Err(_))));
+
+    let mut lexer = Lexer::new("'a'");
+    assert_eq!(next(&mut lexer), Some(Ok("'a'")));
+    assert_eq!(next(&mut lexer), None);
 }

--- a/crates/lexgen/tests/tests.rs
+++ b/crates/lexgen/tests/tests.rs
@@ -991,3 +991,51 @@ fn loc_tracking() {
         Some(Ok((loc(1, 0, 17), "ｗｏｒｌｄ!!!", loc(1, 13, 35))))
     );
 }
+
+#[test]
+fn diff_1() {
+    lexer! {
+        Lexer -> &'input str;
+
+        ['0'-'9'] # ['3'-'7'] => |lexer| {
+            let match_ = lexer.match_();
+            lexer.return_(match_)
+        },
+    }
+
+    let mut lexer = Lexer::new("01289");
+    assert_eq!(next(&mut lexer), Some(Ok("0")));
+    assert_eq!(next(&mut lexer), Some(Ok("1")));
+    assert_eq!(next(&mut lexer), Some(Ok("2")));
+    assert_eq!(next(&mut lexer), Some(Ok("8")));
+    assert_eq!(next(&mut lexer), Some(Ok("9")));
+    assert_eq!(next(&mut lexer), None);
+
+    let mut lexer = Lexer::new("34567");
+    assert!(matches!(next(&mut lexer), Some(Err(_))));
+    assert!(matches!(next(&mut lexer), Some(Err(_))));
+    assert!(matches!(next(&mut lexer), Some(Err(_))));
+    assert!(matches!(next(&mut lexer), Some(Err(_))));
+    assert!(matches!(next(&mut lexer), Some(Err(_))));
+    assert!(matches!(next(&mut lexer), None));
+}
+
+#[test]
+fn diff_2() {
+    lexer! {
+        Lexer -> &'input str;
+
+        _ # 'a' => |lexer| {
+            let match_ = lexer.match_();
+            lexer.return_(match_)
+        },
+    }
+
+    let mut lexer = Lexer::new("b");
+    assert_eq!(next(&mut lexer), Some(Ok("b")));
+    assert!(matches!(next(&mut lexer), None));
+
+    let mut lexer = Lexer::new("a");
+    assert!(matches!(next(&mut lexer), Some(Err(_))));
+    assert!(matches!(next(&mut lexer), None));
+}


### PR DESCRIPTION
Implements new syntax `<re1> # <re2>` for matching characters in `<re1>` that
are not in `<re2>`. `<re1>` and `<re2>` should be "character sets", i.e. `*`,
`+`, `?`, concatenation, strings, and `$` are not allowed.

Fixes #24