### PR TITLE
Annotate custom errors with location info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@
   "character sets", i.e. `*`, `+`, `?`, `"..."`, `$`, and concatenation are not
   allowed.
 
+- **Breaking change:** `LexerError` type is refactored to add location
+  information to all errors, not just `InvalidToken`. Previously the type was:
+
+  ```rust
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub enum LexerError<E> {
+      InvalidToken {
+          location: Loc,
+      },
+  
+      /// Custom error, raised by a semantic action
+      Custom(E),
+  }
+  ```
+
+  with this change, it is now:
+
+  ```rust
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct LexerError<E> {
+      pub location: Loc,
+      pub kind: LexerErrorKind<E>,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub enum LexerErrorKind<E> {
+      /// Lexer error, raised by lexgen-generated code
+      InvalidToken,
+  
+      /// Custom error, raised by a semantic action
+      Custom(E),
+  }
+  ```
+
 # 2021/11/30: 0.8.1
 
 New version published to fix broken README pages for lexgen and lexgen_util in

--- a/crates/lexgen/src/dfa/codegen.rs
+++ b/crates/lexgen/src/dfa/codegen.rs
@@ -513,7 +513,10 @@ fn generate_rhs_code(ctx: &CgCtx, action: SemanticActionIdx) -> TokenStream {
 fn generate_semantic_action_call(action_fn: &TokenStream) -> TokenStream {
     let map_res = quote!(match res {
         Ok(tok) => Ok((match_start, tok, match_end)),
-        Err(err) => Err(::lexgen_util::LexerError::Custom(err)),
+        Err(err) => Err(::lexgen_util::LexerError {
+            location: self.0.match_loc().0,
+            kind: ::lexgen_util::LexerErrorKind::Custom(err),
+        }),
     });
 
     quote!(match #action_fn(self) {

--- a/crates/lexgen/tests/bugs.rs
+++ b/crates/lexgen/tests/bugs.rs
@@ -1,7 +1,7 @@
 mod test_utils;
 
 use lexgen::lexer;
-use lexgen_util::LexerError;
+use lexgen_util::{LexerError, LexerErrorKind};
 use test_utils::{loc, next};
 
 #[test]
@@ -342,8 +342,9 @@ fn empty_rule_simpification_issue_27() {
     // This used to return `Some("wat")` with the bug
     assert_eq!(
         next(&mut lexer),
-        Some(Err(LexerError::InvalidToken {
-            location: loc(0, 0, 0)
+        Some(Err(LexerError {
+            location: loc(0, 0, 0),
+            kind: LexerErrorKind::InvalidToken,
         }))
     );
 }

--- a/crates/lexgen/tests/tests.rs
+++ b/crates/lexgen/tests/tests.rs
@@ -1,7 +1,7 @@
 mod test_utils;
 
 use lexgen::lexer;
-use lexgen_util::{LexerError, Loc};
+use lexgen_util::{LexerError, LexerErrorKind, Loc};
 use test_utils::{loc, next};
 
 use std::convert::TryFrom;
@@ -465,7 +465,10 @@ fn rule_kind_fallible_no_lifetimes() {
     );
     assert!(matches!(
         lexer.next(),
-        Some(Err(::lexgen_util::LexerError::Custom(_)))
+        Some(Err(LexerError {
+            kind: LexerErrorKind::Custom(_),
+            ..
+        }))
     ));
     assert_eq!(lexer.next(), None);
 }
@@ -502,7 +505,10 @@ fn rule_kind_fallible_with_lifetimes() {
     );
     assert!(matches!(
         lexer.next(),
-        Some(Err(::lexgen_util::LexerError::Custom(UserError("blah"))))
+        Some(Err(LexerError {
+            kind: LexerErrorKind::Custom(UserError("blah")),
+            ..
+        }))
     ));
     assert_eq!(lexer.next(), None);
 }
@@ -552,7 +558,10 @@ fn rule_kind_mix() {
     );
     assert!(matches!(
         lexer.next(),
-        Some(Err(::lexgen_util::LexerError::Custom(UserError("blah"))))
+        Some(Err(LexerError {
+            kind: LexerErrorKind::Custom(UserError("blah")),
+            ..
+        }))
     ));
     assert_eq!(lexer.next(), None);
 
@@ -1086,8 +1095,9 @@ fn diff_4() {
     assert_eq!(next(&mut lexer), Some(Ok("// asdf")));
     assert_eq!(
         next(&mut lexer),
-        Some(Err(LexerError::InvalidToken {
-            location: loc(0, 7, 7)
+        Some(Err(LexerError {
+            location: loc(0, 7, 7),
+            kind: LexerErrorKind::InvalidToken,
         }))
     );
 }

--- a/crates/lexgen_util/src/lib.rs
+++ b/crates/lexgen_util/src/lib.rs
@@ -1,10 +1,15 @@
 use unicode_width::UnicodeWidthChar;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum LexerError<E> {
-    InvalidToken {
-        location: Loc,
-    },
+pub struct LexerError<E> {
+    pub location: Loc,
+    pub kind: LexerErrorKind<E>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LexerErrorKind<E> {
+    /// Lexer error, raised by lexgen-generated code
+    InvalidToken,
 
     /// Custom error, raised by a semantic action
     Custom(E),
@@ -143,8 +148,9 @@ impl<'input, T, S, E, W> Lexer<'input, T, S, E, W> {
     ) -> Result<for<'lexer> fn(&'lexer mut W) -> SemanticActionResult<Result<T, E>>, LexerError<E>>
     {
         match self.last_match.take() {
-            None => Err(LexerError::InvalidToken {
+            None => Err(LexerError {
                 location: self.current_match_start,
+                kind: LexerErrorKind::InvalidToken,
             }),
             Some((match_start, semantic_action, match_end)) => {
                 self.__done = false;


### PR DESCRIPTION
This commit changes LexerError type from:

    #[derive(Debug, Clone, PartialEq, Eq)]
    pub enum LexerError<E> {
        InvalidToken {
            location: Loc,
        },

        /// Custom error, raised by a semantic action
        Custom(E),
    }

to:

    #[derive(Debug, Clone, PartialEq, Eq)]
    pub struct LexerError<E> {
        pub location: Loc,
        pub kind: LexerErrorKind<E>,
    }

    #[derive(Debug, Clone, PartialEq, Eq)]
    pub enum LexerErrorKind<E> {
        /// Lexer error, raised by lexgen-generated code
        InvalidToken,

        /// Custom error, raised by a semantic action
        Custom(E),
    }

So we annotate *all* errors with location info now.