### PR TITLE
Fix redundant backtrack calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Lexers can now use `pub(crate)` visibility, and other visibilities supported
   by Rust and the `syn` crate. Previously only `pub` was supported.
 
+- Eliminate redundant `backtrack` calls in generated code, improving code size
+  and runtime performance. Runtime performance improved 13% in a benchmark.
+  (#69)
+
 # 2023/09/03: 0.15.0
 
 - Lexer type declarations can now have outer attributes other than just

--- a/crates/lexgen/src/dfa/backtrack.rs
+++ b/crates/lexgen/src/dfa/backtrack.rs
@@ -1,0 +1,64 @@
+use crate::collections::Map;
+use crate::dfa::{StateIdx, DFA};
+
+use std::collections::hash_map::Entry;
+
+pub(crate) fn update_backtracks<A>(dfa: &mut DFA<StateIdx, A>) {
+    // State and whether the state is an accepting state.
+    let mut work_list: Vec<(StateIdx, bool)> = dfa
+        .states
+        .iter()
+        .enumerate()
+        .filter_map(|(state_idx, state)| {
+            if state.initial {
+                Some((StateIdx(state_idx), false))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Set of visited nodes, with their backtrack state when visited. If a state's backtrack
+    // property changes, we visit it again to make its successors backtrack.
+    let mut visited: Map<StateIdx, bool> = Default::default();
+
+    while let Some((state, backtrack)) = work_list.pop() {
+        // Did we visit the state, with the right backtrack state?
+        match visited.entry(state) {
+            Entry::Occupied(mut entry) => {
+                if *entry.get() == backtrack {
+                    continue;
+                }
+                entry.insert(backtrack);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(backtrack);
+            }
+        }
+
+        // Whether the successor states should backtrack.
+        let successor_backtrack = backtrack || dfa.is_accepting_state(state);
+
+        for (_, next) in &dfa.states[state.0].char_transitions {
+            work_list.push((*next, successor_backtrack));
+        }
+
+        for next_range in dfa.states[state.0].range_transitions.iter() {
+            work_list.push((next_range.value, successor_backtrack));
+        }
+
+        if let Some(next) = dfa.states[state.0].any_transition {
+            work_list.push((next, successor_backtrack));
+        }
+
+        if let Some(next) = dfa.states[state.0].end_of_input_transition {
+            work_list.push((next, successor_backtrack));
+        }
+    }
+
+    assert_eq!(visited.len(), dfa.states.len());
+
+    for (state, backtrack) in visited {
+        dfa.states[state.0].backtrack = backtrack;
+    }
+}

--- a/crates/lexgen/src/dfa/simplify.rs
+++ b/crates/lexgen/src/dfa/simplify.rs
@@ -50,6 +50,7 @@ pub fn simplify<K, A: Clone>(
                 end_of_input_transition,
                 accepting,
                 predecessors,
+                backtrack,
             } = state;
 
             let char_transitions = char_transitions
@@ -83,6 +84,7 @@ pub fn simplify<K, A: Clone>(
                 end_of_input_transition,
                 accepting,
                 predecessors,
+                backtrack,
             }
         })
         .collect();

--- a/crates/lexgen/src/lib.rs
+++ b/crates/lexgen/src/lib.rs
@@ -140,10 +140,12 @@ pub fn lexer(input: TokenStream) -> TokenStream {
         }
     }
 
-    let dfa = match init_dfa {
+    let mut dfa = match init_dfa {
         Some(init_dfa) => init_dfa,
         None => nfa_to_dfa(&unnamed_nfa),
     };
+
+    dfa::update_backtracks(&mut dfa);
 
     let dfa = dfa::simplify::simplify(dfa, &mut dfas);
 


### PR DESCRIPTION
Improves [this lexgen benchmark][1] from 167 MB/s to 190 MB/s, 13%.

Fixes #68. All of the `backtrack` calls in the repro in the issue are eliminated with this change.

[1]: https://github.com/osa1/how-to-parse/blob/main/part1/bin/bench.rs#L76-L89