### PR TITLE
Mark generated internal types as `#[doc(hidden)]`

### DIFF
--- a/crates/lexgen/src/dfa/codegen.rs
+++ b/crates/lexgen/src/dfa/codegen.rs
@@ -202,6 +202,7 @@ pub fn generate(
         }
 
         #(#attrs)*
+        #[doc(hidden)]
         #visibility struct #lexer_struct_name<'input, #(#user_state_lifetimes,)* I: Iterator<Item = char> + Clone, S>(
             ::lexgen_util::Lexer<
                 'input,
@@ -725,6 +726,7 @@ fn generate_semantic_action_fns(
             };
 
             quote!(
+                #[doc(hidden)]
                 #[allow(non_snake_case)]
                 fn #ident<'lexer, #(#user_state_lifetimes, )* 'input, I: Iterator<Item = char> + Clone>(lexer: &'lexer mut #lexer_name<'input, #(#user_state_lifetimes, )* I>) -> #semantic_action_fn_ret_ty {
                     let action: fn(&'lexer mut #lexer_name<'input, #(#user_state_lifetimes, )* I>) -> #semantic_action_fn_ret_ty = #rhs;


### PR DESCRIPTION
Hi there. I noticed that in cases where `rustdoc --document-private-items` is used in projects that use `lexgen`, a number of noisy/blackbox types are also emitted (see screenshot). This PR silences them entirely, since they'll probably never be useful to have documented at all.

![image](https://github.com/user-attachments/assets/e26fb8bd-7528-46d4-8b1c-29654d2e0b35)
