### PR TITLE
Normalise ranges of transitions of states of DFA before codegen

### DIFF
--- a/crates/lexgen/src/dfa.rs
+++ b/crates/lexgen/src/dfa.rs
@@ -1,5 +1,6 @@
 mod backtrack;
 pub mod codegen;
+pub mod normalise;
 pub mod simplify;
 
 #[cfg(test)]

--- a/crates/lexgen/src/dfa/normalise.rs
+++ b/crates/lexgen/src/dfa/normalise.rs
@@ -1,0 +1,20 @@
+use std::ops::RangeInclusive;
+
+use crate::DFA;
+
+const CHAR_GAP: RangeInclusive<u32> = 0xD800..=0xDFFF;
+
+/// Move range ends out of char gaps
+pub fn normalise_ranges<T, A>(dfa: &mut DFA<T, A>) {
+    for state in dfa.states.iter_mut() {
+        for range in state.range_transitions.iter_mut() {
+            if CHAR_GAP.contains(&range.start) {
+                range.start = CHAR_GAP.end() + 1;
+            }
+
+            if CHAR_GAP.contains(&range.end) {
+                range.end = CHAR_GAP.start() - 1;
+            }
+        }
+    }
+}

--- a/crates/lexgen/src/dfa/normalise.rs
+++ b/crates/lexgen/src/dfa/normalise.rs
@@ -46,14 +46,14 @@ fn normalisation_correct() {
 
     let mut nfa = crate::NFA::new();
 
+    nfa.add_regex(&Default::default(), &Regex::Char('\u{E000}'), None, 1);
+    nfa.add_regex(&Default::default(), &Regex::Char('\u{D7FF}'), None, 2);
     nfa.add_regex(
         &Default::default(),
         &Regex::CharSet(CharSet(vec![CharOrRange::Range('\u{D7DD}', '\u{E000}')])),
         None,
-        1,
+        3,
     );
-    nfa.add_regex(&Default::default(), &Regex::Char('\u{E000}'), None, 2);
-    nfa.add_regex(&Default::default(), &Regex::Char('\u{D7FF}'), None, 3);
 
     let mut dfa = crate::nfa_to_dfa(&nfa);
 

--- a/crates/lexgen/src/dfa/normalise.rs
+++ b/crates/lexgen/src/dfa/normalise.rs
@@ -7,14 +7,62 @@ const CHAR_GAP: RangeInclusive<u32> = 0xD800..=0xDFFF;
 /// Move range ends out of char gaps
 pub fn normalise_ranges<T, A>(dfa: &mut DFA<T, A>) {
     for state in dfa.states.iter_mut() {
-        for range in state.range_transitions.iter_mut() {
-            if CHAR_GAP.contains(&range.start) {
-                range.start = CHAR_GAP.end() + 1;
-            }
+        state.range_transitions.retain_mut(|range| {
+            let start_nonnormal = CHAR_GAP.contains(&range.start);
+            let end_nonnormal = CHAR_GAP.contains(&range.end);
 
-            if CHAR_GAP.contains(&range.end) {
-                range.end = CHAR_GAP.start() - 1;
+            match (start_nonnormal, end_nonnormal) {
+                //        S E
+                // ... G .^.^. G ...
+                (true, true) => false,
+                //         S      E
+                // ... G ..^.. G .^.
+                (true, false) => {
+                    // Move the start after the gap
+                    range.start = CHAR_GAP.end() + 1;
+                    true
+                }
+                //  S      E
+                // .^. G ..^.. G ...
+                (false, true) => {
+                    // Move the end before the gap
+                    range.end = CHAR_GAP.start() - 1;
+                    true
+                }
+                // Any other case (either both are before or after the gap or contain it).
+                // It doesn't matter if the range contains the gap - that's fine
+                (false, false) => true,
             }
+        });
+    }
+}
+
+#[test]
+fn normalisation_correct() {
+    // See test normalisation_sound() (tests/tests.rs:1294)
+    // for the equivalent lexer being constructed here
+
+    use crate::ast::{CharOrRange, CharSet, Regex};
+
+    let mut nfa = crate::NFA::new();
+
+    nfa.add_regex(
+        &Default::default(),
+        &Regex::CharSet(CharSet(vec![CharOrRange::Range('\u{D7DD}', '\u{E000}')])),
+        None,
+        1,
+    );
+    nfa.add_regex(&Default::default(), &Regex::Char('\u{E000}'), None, 2);
+    nfa.add_regex(&Default::default(), &Regex::Char('\u{D7FF}'), None, 3);
+
+    let mut dfa = crate::nfa_to_dfa(&nfa);
+
+    crate::dfa::normalise::normalise_ranges(&mut dfa);
+
+    for state in dfa.states.iter() {
+        for range in state.range_transitions.iter() {
+            assert!(!CHAR_GAP.contains(&range.start), "start is in the gap");
+            assert!(!CHAR_GAP.contains(&range.end), "end is in the gap");
         }
     }
 }

--- a/crates/lexgen/src/lib.rs
+++ b/crates/lexgen/src/lib.rs
@@ -147,7 +147,8 @@ pub fn lexer(input: TokenStream) -> TokenStream {
 
     dfa::update_backtracks(&mut dfa);
 
-    let dfa = dfa::simplify::simplify(dfa, &mut dfas);
+    let mut dfa = dfa::simplify::simplify(dfa, &mut dfas);
+    dfa::normalise::normalise_ranges(&mut dfa);
 
     dfa::codegen::generate(
         dfa,

--- a/crates/lexgen/src/range_map.rs
+++ b/crates/lexgen/src/range_map.rs
@@ -59,6 +59,10 @@ impl<A> RangeMap<A> {
         self.ranges.iter()
     }
 
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Range<A>> {
+        self.ranges.iter_mut()
+    }
+
     pub fn into_iter(self) -> impl Iterator<Item = Range<A>> {
         self.ranges.into_iter()
     }

--- a/crates/lexgen/src/range_map.rs
+++ b/crates/lexgen/src/range_map.rs
@@ -59,12 +59,12 @@ impl<A> RangeMap<A> {
         self.ranges.iter()
     }
 
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Range<A>> {
-        self.ranges.iter_mut()
-    }
-
     pub fn into_iter(self) -> impl Iterator<Item = Range<A>> {
         self.ranges.into_iter()
+    }
+
+    pub fn retain_mut<F: FnMut(&mut Range<A>) -> bool>(&mut self, f: F) {
+        self.ranges.retain_mut(f);
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/lexgen/tests/tests.rs
+++ b/crates/lexgen/tests/tests.rs
@@ -1289,3 +1289,19 @@ fn visibility() {
         'a' = 1,
     }
 }
+
+#[test]
+fn normalisation_sound() {
+    lexer! {
+        pub(crate) Lexer -> usize;
+
+        '\u{E000}' = 1,
+        '\u{D7FF}' = 2,
+        ['\u{D7DD}'-'\u{E000}'] = 3,
+    }
+
+    let mut lexer = Lexer::new("\u{E000}\u{D7FF}\u{D7DF}");
+    assert_eq!(next(&mut lexer), Some(Ok(1)));
+    assert_eq!(next(&mut lexer), Some(Ok(2)));
+    assert_eq!(next(&mut lexer), Some(Ok(3)));
+}


### PR DESCRIPTION
This makes so that if a range ends within the char gap, it moves it accordingly out of that gap.

I couldn't come up with a better name than "normalisation" for this, so I stuck with it.

Neither I know if testing is necessary for this feature.